### PR TITLE
added hitTest-method to activate touches between tabBarItems

### DIFF
--- a/FoldingTabBar/View/FoldingTabBar/YALFoldingTabBar.m
+++ b/FoldingTabBar/View/FoldingTabBar/YALFoldingTabBar.m
@@ -664,4 +664,11 @@ typedef NS_ENUM(NSUInteger, YALAnimatingState) {
     });
 }
 
+// will "activate" touches behind tabBar or better between tabBarItems
+-(id)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    id hitView = [super hitTest:point withEvent:event];
+    if (hitView == self.mainView) return nil;
+    else return hitView;
+}
+
 @end


### PR DESCRIPTION
The hitTest will check if the user touches the tabBar or the the view behind. This will help to use the FoldingTabBar with a ScrollView (i.e. a TableView) and "activates" touches on this ScrollView behind the TabBar.

Resolves issue #16 !
